### PR TITLE
#5 - deploy update site automatically on each master build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,19 @@ cache:
   - $HOME/.m2
   - $HOME/.gradle/
 deploy:
-  provider: releases
-  api_key:  ${DEPLOY_TOKEN}
-  file: com.github.camel-tooling.lsp.eclipse.updatesite/target/com.github.camel-tooling.eclipse.updatesite-1.0.0-SNAPSHOT.zip
-  skip_cleanup: true
-  overwrite: true
-  on:
-    branch:  master
+  - provider: releases
+    api_key:  ${DEPLOY_TOKEN}
+    file: com.github.camel-tooling.lsp.eclipse.updatesite/target/com.github.camel-tooling.eclipse.updatesite-1.0.0-SNAPSHOT.zip
+    skip_cleanup: true
+    overwrite: true
+    on:
+      branch:  master
+  - provider: pages
+    skip_cleanup: true
+    github_token: ${GITHUB_TOKEN}
+    local_dir: com.github.camel-tooling.lsp.eclipse.updatesite/target/repository
+    repo: camel-tooling/camel-lsp-client-eclipse-update-site
+    target_branch: master
+    on:
+      branch: master
 


### PR DESCRIPTION
I launched a version with deploy on update-site branch, and it works! see https://travis-ci.org/camel-tooling/camel-lsp-client-eclipse/builds/368509103

![image](https://user-images.githubusercontent.com/1105127/38977219-fbdad702-43b3-11e8-8aeb-be20d2678a58.png)

I modified after the branch to have deploy only on master and a clean history
