### PR TITLE
#39 - provide Java DSL for Camel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 When using the Generic Text editor, completion and documentation on hover are supported. See [here](https://github.com/camel-tooling/camel-language-server/blob/master/README.md#features) for details.
 
-When using XML editor, only the completion is provided.
+When using XML or Java editor, only the completion is provided.
 
 
 # How to Install

--- a/com.github.camel-tooling.lsp.eclipse.client/META-INF/MANIFEST.MF
+++ b/com.github.camel-tooling.lsp.eclipse.client/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.lsp4e;bundle-version="0.6.0",
  org.eclipse.core.runtime;bundle-version="3.13.0",
  org.eclipse.jface.text;bundle-version="3.12.0",
- org.eclipse.wst.sse.ui;bundle-version="1.3.600"
+ org.eclipse.wst.sse.ui;bundle-version="1.3.600",
+ org.eclipse.jdt.ui
 Export-Package: com.github.cameltooling.eclipse.client;x-friends:="com.github.camel-tooling.eclipse.client.tests.integration"
 Eclipse-BundleShape: dir
 Bundle-Activator: com.github.cameltooling.eclipse.client.ActivatorCamelLspClient

--- a/com.github.camel-tooling.lsp.eclipse.client/plugin.xml
+++ b/com.github.camel-tooling.lsp.eclipse.client/plugin.xml
@@ -5,13 +5,23 @@
          point="org.eclipse.lsp4e.languageServer">
       <contentTypeMapping
             contentType="org.eclipse.core.runtime.xml"
-            id="Camel LSP Server"
+            id="Camel LSP Server for XML"
+            languageId="LANGUAGE_ID_APACHE_CAMEL">
+     </contentTypeMapping>
+     <contentTypeMapping
+            contentType="org.eclipse.jdt.core.javaSource"
+            id="Camel LSP Server for Java"
             languageId="LANGUAGE_ID_APACHE_CAMEL">
       </contentTypeMapping>
       <server
             class="com.github.cameltooling.eclipse.client.CamelLSPStreamConnectionProvider"
-            id="Camel LSP Server"
-            label="Camel LSP Server">
+            id="Camel LSP Server for Java"
+            label="Camel LSP Server for Java">
+      </server>
+      <server
+            class="com.github.cameltooling.eclipse.client.CamelLSPStreamConnectionProvider"
+            id="Camel LSP Server for XML"
+            label="Camel LSP Server for XML">
       </server>
    </extension>
    <extension
@@ -28,6 +38,16 @@
        id="org.apache.camel.xml.proposalcomputer">      
     <contentType id="org.eclipse.core.runtime.xml"/>      
   </proposalComputer> 
+   </extension>
+   <extension
+         id="id1"
+         point="org.eclipse.jdt.ui.javaCompletionProposalComputer">
+      <javaCompletionProposalComputer
+            activate="true"
+            categoryId="org.eclipse.jdt.ui.defaultProposalCategory"
+            class="com.github.cameltooling.eclipse.java.completion.CamelCompletionProposalComputer"
+            needsSortingAfterFiltering="false">
+      </javaCompletionProposalComputer>
    </extension>
 
 </plugin>

--- a/com.github.camel-tooling.lsp.eclipse.client/src/com/github/cameltooling/eclipse/java/completion/CamelCompletionProposalComputer.java
+++ b/com.github.camel-tooling.lsp.eclipse.client/src/com/github/cameltooling/eclipse/java/completion/CamelCompletionProposalComputer.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.eclipse.java.completion;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.ui.text.java.ContentAssistInvocationContext;
+import org.eclipse.jdt.ui.text.java.IJavaCompletionProposalComputer;
+import org.eclipse.jface.text.contentassist.ICompletionProposal;
+import org.eclipse.jface.text.contentassist.IContextInformation;
+import org.eclipse.lsp4e.operations.completion.LSContentAssistProcessor;
+
+public class CamelCompletionProposalComputer implements IJavaCompletionProposalComputer {
+
+	@Override
+	public List<ICompletionProposal> computeCompletionProposals(ContentAssistInvocationContext context, IProgressMonitor monitor) {
+		return Arrays.asList(new LSContentAssistProcessor().computeCompletionProposals(context.getViewer(), context.getInvocationOffset()));
+	}
+
+	@Override
+	public List<IContextInformation> computeContextInformation(ContentAssistInvocationContext context, IProgressMonitor monitor) {
+		return Arrays.asList(new LSContentAssistProcessor().computeContextInformation(context.getViewer(), context.getInvocationOffset()));
+	}
+
+	@Override
+	public String getErrorMessage() {
+		return null;
+	}
+	
+	@Override
+	public void sessionStarted() {
+		// nothing to do
+	}
+
+	@Override
+	public void sessionEnded() {
+		// nothing to do
+	}
+
+}


### PR DESCRIPTION
- in Generic text editor
- completion in Java classical editor

Signed-off-by: Aurélien Pupier <apupier@redhat.com>