### PR TITLE
Upgrade to Jacoco 0.8.2 to be Java 11 ready #54

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.1</version>
+				<version>0.8.2</version>
 				<configuration>
 					<append>true</append>
 					<includes>com.github.cameltooling.lsp.*,com.github.cameltooling.*</includes>


### PR DESCRIPTION
 same coverage than before with this version so seems fine:
![image](https://user-images.githubusercontent.com/1105127/49163253-f50a3e80-f32c-11e8-9312-eda078e7700d.png)
