### PR TITLE
Upgrade Target Platform to Eclipse 2019-03 #73

### DIFF
--- a/camel-lsp-target-platform/camel-lsp-target-platform.target
+++ b/camel-lsp-target-platform/camel-lsp-target-platform.target
@@ -2,41 +2,41 @@
 <?pde version="3.8"?><target name="camel-lsp-eclipse" sequenceNumber="7">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.pde.feature.group" version="3.13.100.v20180611-0826"/>
-<unit id="org.eclipse.pde.source.feature.group" version="3.13.100.v20180611-0826"/>
-<unit id="org.eclipse.sdk.ide" version="4.8.0.I20180611-0500"/>
-<unit id="org.eclipse.sdk.tests.feature.group" version="4.8.0.v20180611-0500"/>
-<unit id="org.eclipse.test.feature.group" version="3.7.300.v20180524-2246"/>
-<repository location="http://download.eclipse.org/eclipse/updates/4.8/"/>
+<unit id="org.eclipse.pde.feature.group" version="3.13.400.v20190307-0943"/>
+<unit id="org.eclipse.pde.source.feature.group" version="3.13.400.v20190307-0943"/>
+<unit id="org.eclipse.sdk.ide" version="4.11.0.I20190307-0500"/>
+<unit id="org.eclipse.sdk.tests.feature.group" version="4.11.0.v20190307-0500"/>
+<unit id="org.eclipse.test.feature.group" version="3.7.600.v20190107-0639"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.11/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.assertj" version="1.7.1.v20170413-2026"/>
 <unit id="org.assertj.source" version="1.7.1.v20170413-2026"/>
-<repository location="http://download.eclipse.org/tools/orbit/R-builds/R20180606145124/repository"/>
+<repository location="https://download.eclipse.org/tools/orbit/R-builds/R20190226160451/repository"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.lsp4e" version="0.6.0.201805171449"/>
-<unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.4.1.v20180515-1323"/>
-<unit id="org.eclipse.wst.xml_ui.feature.feature.group" version="3.10.0.v201804210200"/>
-<repository location="http://download.eclipse.org/releases/photon"/>
+<unit id="org.eclipse.lsp4e" version="0.9.0.201903130753"/>
+<unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.7.0.v20190228-1519"/>
+<unit id="org.eclipse.wst.xml_ui.feature.feature.group" version="3.13.0.v201903050402"/>
+<repository location="https://download.eclipse.org/releases/2019-03"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.reddeer.codegen.feature.feature.group" version="2.4.0.v20181212-1430"/>
-<unit id="org.eclipse.reddeer.eclipse.feature.feature.group" version="2.4.0.v20181212-1430"/>
-<unit id="org.eclipse.reddeer.eclipse.feature.source.feature.group" version="2.4.0.v20181212-1430"/>
-<unit id="org.eclipse.reddeer.gef.spy.feature.feature.group" version="2.4.0.v20181212-1430"/>
-<unit id="org.eclipse.reddeer.graphiti.feature.feature.group" version="2.4.0.v20181212-1430"/>
-<unit id="org.eclipse.reddeer.graphiti.feature.source.feature.group" version="2.4.0.v20181212-1430"/>
-<unit id="org.eclipse.reddeer.logparser.feature.feature.group" version="2.4.0.v20181212-1430"/>
-<unit id="org.eclipse.reddeer.logparser.feature.source.feature.group" version="2.4.0.v20181212-1430"/>
-<unit id="org.eclipse.reddeer.recorder.feature.feature.group" version="2.4.0.v20181212-1430"/>
-<unit id="org.eclipse.reddeer.recorder.feature.source.feature.group" version="2.4.0.v20181212-1430"/>
-<unit id="org.eclipse.reddeer.spy.feature.feature.group" version="2.4.0.v20181212-1430"/>
-<unit id="org.eclipse.reddeer.swt.feature.feature.group" version="2.4.0.v20181212-1430"/>
-<unit id="org.eclipse.reddeer.swt.feature.source.feature.group" version="2.4.0.v20181212-1430"/>
-<unit id="org.eclipse.reddeer.ui.feature.feature.group" version="2.4.0.v20181212-1430"/>
-<unit id="org.eclipse.reddeer.ui.feature.source.feature.group" version="2.4.0.v20181212-1430"/>
-<repository location="http://download.eclipse.org/reddeer/releases/2.4.0"/>
+<unit id="org.eclipse.reddeer.codegen.feature.feature.group" version="2.5.0.v20190313-1442"/>
+<unit id="org.eclipse.reddeer.eclipse.feature.feature.group" version="2.5.0.v20190313-1442"/>
+<unit id="org.eclipse.reddeer.eclipse.feature.source.feature.group" version="2.5.0.v20190313-1442"/>
+<unit id="org.eclipse.reddeer.gef.spy.feature.feature.group" version="2.5.0.v20190313-1442"/>
+<unit id="org.eclipse.reddeer.graphiti.feature.feature.group" version="2.5.0.v20190313-1442"/>
+<unit id="org.eclipse.reddeer.graphiti.feature.source.feature.group" version="2.5.0.v20190313-1442"/>
+<unit id="org.eclipse.reddeer.logparser.feature.feature.group" version="2.5.0.v20190313-1442"/>
+<unit id="org.eclipse.reddeer.logparser.feature.source.feature.group" version="2.5.0.v20190313-1442"/>
+<unit id="org.eclipse.reddeer.recorder.feature.feature.group" version="2.5.0.v20190313-1442"/>
+<unit id="org.eclipse.reddeer.recorder.feature.source.feature.group" version="2.5.0.v20190313-1442"/>
+<unit id="org.eclipse.reddeer.spy.feature.feature.group" version="2.5.0.v20190313-1442"/>
+<unit id="org.eclipse.reddeer.swt.feature.feature.group" version="2.5.0.v20190313-1442"/>
+<unit id="org.eclipse.reddeer.swt.feature.source.feature.group" version="2.5.0.v20190313-1442"/>
+<unit id="org.eclipse.reddeer.ui.feature.feature.group" version="2.5.0.v20190313-1442"/>
+<unit id="org.eclipse.reddeer.ui.feature.source.feature.group" version="2.5.0.v20190313-1442"/>
+<repository location="https://download.eclipse.org/reddeer/releases/2.5.0"/>
 </location>
 </locations>
 </target>

--- a/camel-lsp-target-platform/camel-lsp-target-platform.target
+++ b/camel-lsp-target-platform/camel-lsp-target-platform.target
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="camel-lsp-eclipse" sequenceNumber="7">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="camel-lsp-eclipse" sequenceNumber="7">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.pde.feature.group" version="3.13.400.v20190307-0943"/>
@@ -7,6 +6,7 @@
 <unit id="org.eclipse.sdk.ide" version="4.11.0.I20190307-0500"/>
 <unit id="org.eclipse.sdk.tests.feature.group" version="4.11.0.v20190307-0500"/>
 <unit id="org.eclipse.test.feature.group" version="3.7.600.v20190107-0639"/>
+<unit id="org.eclipse.jface.text.tests" version="3.11.500.v20190305-1052"/>
 <repository location="https://download.eclipse.org/eclipse/updates/4.11/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/com.github.camel-tooling.lsp.eclipse.client.tests.integration/META-INF/MANIFEST.MF
+++ b/com.github.camel-tooling.lsp.eclipse.client.tests.integration/META-INF/MANIFEST.MF
@@ -15,4 +15,6 @@ Require-Bundle: org.junit;bundle-version="4.12.0",
  org.eclipse.core.resources;bundle-version="3.12.0",
  org.eclipse.core.runtime;bundle-version="3.13.0",
  org.eclipse.ui.genericeditor;bundle-version="1.0.1",
- org.eclipse.ui.workbench.texteditor;bundle-version="3.10.100"
+ org.eclipse.ui.workbench.texteditor;bundle-version="3.10.100",
+ org.eclipse.jface.text.tests;bundle-version="3.11.500",
+ org.eclipse.ui;bundle-version="3.112.0"

--- a/com.github.camel-tooling.lsp.eclipse.client.tests.integration/src/main/java/com/github/cameltooling/eclipse/client/tests/integration/CamelLSPLoadedByExtensionPointIT.java
+++ b/com.github.camel-tooling.lsp.eclipse.client.tests.integration/src/main/java/com/github/cameltooling/eclipse/client/tests/integration/CamelLSPLoadedByExtensionPointIT.java
@@ -31,18 +31,27 @@ import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
+import org.eclipse.jface.text.tests.util.DisplayHelper;
 import org.eclipse.lsp4e.operations.completion.LSContentAssistProcessor;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.internal.genericeditor.ExtensionBasedTextEditor;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
 import org.eclipse.ui.texteditor.ITextEditor;
+import org.junit.Before;
 import org.junit.Test;
 
 public class CamelLSPLoadedByExtensionPointIT {
 	
 	private static final int ARBITRARY_NUMBER_OF_MINIMAL_CAMEL_COMPONENTS = 200;
+	private ICompletionProposal[] proposals;
+	
+	@Before
+	public void setup() {
+		proposals = null;
+	}
 
 	@Test
 	public void testGenericEditorProvideCompletion() throws Exception {
@@ -57,8 +66,17 @@ public class CamelLSPLoadedByExtensionPointIT {
 		
 		ITextViewer textViewer = getTextViewer(openEditor);
 		
-		ICompletionProposal[] proposals = new LSContentAssistProcessor().computeCompletionProposals(textViewer, 11);
-		assertThat(proposals.length).isGreaterThan(ARBITRARY_NUMBER_OF_MINIMAL_CAMEL_COMPONENTS);
+		new DisplayHelper() {
+			
+			LSContentAssistProcessor lsContentAssistProcessor = new LSContentAssistProcessor();
+
+			@Override
+			protected boolean condition() {
+				proposals = lsContentAssistProcessor.computeCompletionProposals(textViewer, 11);
+				return proposals.length > ARBITRARY_NUMBER_OF_MINIMAL_CAMEL_COMPONENTS;
+			}
+		}.waitForCondition(Display.getDefault(), 3000);
+		
 		checkContainsATimerProposal(proposals);
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho.version>1.2.0</tycho.version>
+		<tycho.version>1.3.0</tycho.version>
 		<base.name>Eclipse Client for Apache Camel Language Server</base.name>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<!-- compiler settings -->


### PR DESCRIPTION
update to Tycho 1.3.0 is mandatory due to
https://bugs.eclipse.org/bugs/show_bug.cgi?id=538737

Signed-off-by: Aurélien Pupier <apupier@redhat.com>