### PR TITLE
Update Target Platform to Eclipse 2019-06 #84

### DIFF
--- a/camel-lsp-target-platform/camel-lsp-target-platform.target
+++ b/camel-lsp-target-platform/camel-lsp-target-platform.target
@@ -1,42 +1,42 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="camel-lsp-eclipse" sequenceNumber="7">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.pde.feature.group" version="3.13.400.v20190307-0943"/>
-<unit id="org.eclipse.pde.source.feature.group" version="3.13.400.v20190307-0943"/>
-<unit id="org.eclipse.sdk.ide" version="4.11.0.I20190307-0500"/>
-<unit id="org.eclipse.sdk.tests.feature.group" version="4.11.0.v20190307-0500"/>
-<unit id="org.eclipse.test.feature.group" version="3.7.600.v20190107-0639"/>
-<unit id="org.eclipse.jface.text.tests" version="3.11.500.v20190305-1052"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.11/"/>
+<unit id="org.eclipse.pde.feature.group" version="3.14.0.v20190605-1800"/>
+<unit id="org.eclipse.pde.source.feature.group" version="3.14.0.v20190605-1800"/>
+<unit id="org.eclipse.sdk.ide" version="4.12.0.I20190605-1800"/>
+<unit id="org.eclipse.sdk.tests.feature.group" version="4.12.0.v20190605-1800"/>
+<unit id="org.eclipse.test.feature.group" version="3.7.700.v20190527-1420"/>
+<unit id="org.eclipse.jface.text.tests" version="3.11.700.v20190519-2344"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.12/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.assertj" version="1.7.1.v20170413-2026"/>
 <unit id="org.assertj.source" version="1.7.1.v20170413-2026"/>
-<repository location="https://download.eclipse.org/tools/orbit/R-builds/R20190226160451/repository"/>
+<repository location="https://download.eclipse.org/tools/orbit/R-builds/R20190602212107/repository"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.lsp4e" version="0.9.0.201903130753"/>
-<unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.7.0.v20190228-1519"/>
-<unit id="org.eclipse.wst.xml_ui.feature.feature.group" version="3.13.0.v201903050402"/>
-<repository location="https://download.eclipse.org/releases/2019-03"/>
+<unit id="org.eclipse.lsp4e" version="0.10.0.201906060902"/>
+<unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.7.2.v20190528-0935"/>
+<unit id="org.eclipse.wst.xml_ui.feature.feature.group" version="3.14.0.v201905291408"/>
+<repository location="https://download.eclipse.org/releases/2019-06"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.reddeer.codegen.feature.feature.group" version="2.5.0.v20190313-1442"/>
-<unit id="org.eclipse.reddeer.eclipse.feature.feature.group" version="2.5.0.v20190313-1442"/>
-<unit id="org.eclipse.reddeer.eclipse.feature.source.feature.group" version="2.5.0.v20190313-1442"/>
-<unit id="org.eclipse.reddeer.gef.spy.feature.feature.group" version="2.5.0.v20190313-1442"/>
-<unit id="org.eclipse.reddeer.graphiti.feature.feature.group" version="2.5.0.v20190313-1442"/>
-<unit id="org.eclipse.reddeer.graphiti.feature.source.feature.group" version="2.5.0.v20190313-1442"/>
-<unit id="org.eclipse.reddeer.logparser.feature.feature.group" version="2.5.0.v20190313-1442"/>
-<unit id="org.eclipse.reddeer.logparser.feature.source.feature.group" version="2.5.0.v20190313-1442"/>
-<unit id="org.eclipse.reddeer.recorder.feature.feature.group" version="2.5.0.v20190313-1442"/>
-<unit id="org.eclipse.reddeer.recorder.feature.source.feature.group" version="2.5.0.v20190313-1442"/>
-<unit id="org.eclipse.reddeer.spy.feature.feature.group" version="2.5.0.v20190313-1442"/>
-<unit id="org.eclipse.reddeer.swt.feature.feature.group" version="2.5.0.v20190313-1442"/>
-<unit id="org.eclipse.reddeer.swt.feature.source.feature.group" version="2.5.0.v20190313-1442"/>
-<unit id="org.eclipse.reddeer.ui.feature.feature.group" version="2.5.0.v20190313-1442"/>
-<unit id="org.eclipse.reddeer.ui.feature.source.feature.group" version="2.5.0.v20190313-1442"/>
-<repository location="https://download.eclipse.org/reddeer/releases/2.5.0"/>
+<unit id="org.eclipse.reddeer.codegen.feature.feature.group" version="2.6.0.v20190612-1247"/>
+<unit id="org.eclipse.reddeer.eclipse.feature.feature.group" version="2.6.0.v20190612-1247"/>
+<unit id="org.eclipse.reddeer.eclipse.feature.source.feature.group" version="2.6.0.v20190612-1247"/>
+<unit id="org.eclipse.reddeer.gef.spy.feature.feature.group" version="2.6.0.v20190612-1247"/>
+<unit id="org.eclipse.reddeer.graphiti.feature.feature.group" version="2.6.0.v20190612-1247"/>
+<unit id="org.eclipse.reddeer.graphiti.feature.source.feature.group" version="2.6.0.v20190612-1247"/>
+<unit id="org.eclipse.reddeer.logparser.feature.feature.group" version="2.6.0.v20190612-1247"/>
+<unit id="org.eclipse.reddeer.logparser.feature.source.feature.group" version="2.6.0.v20190612-1247"/>
+<unit id="org.eclipse.reddeer.recorder.feature.feature.group" version="2.6.0.v20190612-1247"/>
+<unit id="org.eclipse.reddeer.recorder.feature.source.feature.group" version="2.6.0.v20190612-1247"/>
+<unit id="org.eclipse.reddeer.spy.feature.feature.group" version="2.6.0.v20190612-1247"/>
+<unit id="org.eclipse.reddeer.swt.feature.feature.group" version="2.6.0.v20190612-1247"/>
+<unit id="org.eclipse.reddeer.swt.feature.source.feature.group" version="2.6.0.v20190612-1247"/>
+<unit id="org.eclipse.reddeer.ui.feature.feature.group" version="2.6.0.v20190612-1247"/>
+<unit id="org.eclipse.reddeer.ui.feature.source.feature.group" version="2.6.0.v20190612-1247"/>
+<repository location="https://download.eclipse.org/reddeer/releases/2.6.0"/>
 </location>
 </locations>
 </target>


### PR DESCRIPTION
allows to test against the latest release

Signed-off-by: Aurélien Pupier <apupier@redhat.com>