### PR TITLE
Use built-in assertJ to check for optional

### DIFF
--- a/com.github.camel-tooling.lsp.eclipse.client.tests.integration/src/main/java/com/github/cameltooling/eclipse/client/tests/integration/CamelLSPLoadedByExtensionPointIT.java
+++ b/com.github.camel-tooling.lsp.eclipse.client.tests.integration/src/main/java/com/github/cameltooling/eclipse/client/tests/integration/CamelLSPLoadedByExtensionPointIT.java
@@ -70,6 +70,6 @@ public class CamelLSPLoadedByExtensionPointIT {
 		assertThat(Stream.of(proposals)
 			.map(ICompletionProposal::getDisplayString)
 			.filter(displayString -> displayString.contains("timer"))
-			.findFirst().get()).isNotNull();
+			.findFirst()).isNotEmpty();
 	}
 }


### PR DESCRIPTION
requires https://github.com/camel-tooling/camel-lsp-client-eclipse/pull/107 (as the built-in method for assertj requires the newer Target Platform)