### PR TITLE
FUSETOOLS2-880 - publish update site

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,9 @@ jobs:
                   find website/* -name 'index.html' | xargs perl -pi -e "s/##VERSION##/${PLUGIN_VERSION}/g"
                   find website/* -name 'index.html' | xargs perl -pi -e "s/##TYPE##/${DEPLOY_REPO_ROOT}/g"
                   cp -v website/index.html com.github.camel-tooling.lsp.eclipse.updatesite/target/updatesite/${DEPLOY_REPO_ROOT}/
+            - run:
+                name: Publish update site
+                command: bash .circleci/publish.sh
             - store_artifacts:
                  name: Store update site
                  path: com.github.camel-tooling.lsp.eclipse.updatesite/target/updatesite/

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e # Exit with nonzero exit code if anything fails
+
+# save current path
+REPO_PATH=$PWD
+
+# Save some useful information
+SHA=`git rev-parse --verify HEAD`
+
+# Clone the existing gh-pages for this repo into $HOME/gh-pages/
+# Create a new empty branch if gh-pages doesn't exist yet (should only happen on first deploy)
+cd $HOME
+git config --global user.email "circleci@circle-ci.org"
+git config --global user.name "circle-ci"
+git clone --quiet --branch=master https://${GH_PAGES_DEPLOY}@github.com/camel-tooling/camel-lsp-client-eclipse-update-site.git gh-pages > /dev/null
+cd gh-pages
+
+# delete existing data
+rm -Rf updatesite/${DEPLOY_REPO_ROOT}/
+# copy new data 
+cp -r $REPO_PATH/com.github.camel-tooling.lsp.eclipse.updatesite/target/updatesite .
+# Commit and Push the Changes
+git add -f .
+git status
+git commit -m "Deploy ${DEPLOY_REPO_ROOT} update site to GitHub Pages: ${CIRCLE_SHA1} from Circle CI build $CIRCLE_BUILD_NUM"
+git push -fq origin master > /dev/null
+# return to original path
+cd $REPO_PATH


### PR DESCRIPTION
using a specific branch to trigger the push artificially even when not on master, it resulted in:
- this successful build https://app.circleci.com/pipelines/github/camel-tooling/camel-lsp-client-eclipse/28/workflows/c4dc85d1-b91f-48d3-ab19-71203ccca80f/jobs/28/parallel-runs/0/steps/0-106
- with this commit https://github.com/camel-tooling/camel-lsp-client-eclipse-update-site/commit/a8d6e213e80fe23fb3e4ec7978d23f39539c544e
- tested the updated updates site through this URL https://camel-tooling.github.io/camel-lsp-client-eclipse-update-site/updatesite/nightly/