### PR TITLE
FUSETOOLS2-1059 - Provide setting for Kafka Connection URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ After you add this extension to your Eclipse IDE installation, when you use the 
 
    * Provide a specific Camel catalog version through preferences
    
+   * Specify Kafka connection URl through preferences for dynamic completion on Camel kafka component
+   
 When you use the XML or Java editor, only the auto-completion feature is provided.
 
 For detailed information about Apache Camel supported features, see the [Language Server GitHub page](https://github.com/camel-tooling/camel-language-server#features).

--- a/com.github.camel-tooling.lsp.eclipse.client/src/com/github/cameltooling/eclipse/internal/l10n/Messages.java
+++ b/com.github.camel-tooling.lsp.eclipse.client/src/com/github/cameltooling/eclipse/internal/l10n/Messages.java
@@ -25,6 +25,7 @@ public class Messages extends NLS {
 	public static String camelCatalogVersionSettings;
 	public static String camelAdditionalComponentSettings;
 	public static String camelCatalogRuntimeProviderSettings;
+	public static String kafkaConnectionUrlSettings;
 	static {
 		NLS.initializeMessages(BASE_NAME, Messages.class);
 	}

--- a/com.github.camel-tooling.lsp.eclipse.client/src/com/github/cameltooling/eclipse/internal/l10n/messages.properties
+++ b/com.github.camel-tooling.lsp.eclipse.client/src/com/github/cameltooling/eclipse/internal/l10n/messages.properties
@@ -2,3 +2,4 @@ camelCatalogVersionSettings=Catalog version
 camelPreferencePageDescription=To take effect, it requires to close and then reopen editors
 camelAdditionalComponentSettings=Extra components
 camelCatalogRuntimeProviderSettings=Runtime provider
+kafkaConnectionUrlSettings=Kafka connection URL

--- a/com.github.camel-tooling.lsp.eclipse.client/src/com/github/cameltooling/eclipse/preferences/CamelLanguageServerPreferenceManager.java
+++ b/com.github.camel-tooling.lsp.eclipse.client/src/com/github/cameltooling/eclipse/preferences/CamelLanguageServerPreferenceManager.java
@@ -36,6 +36,7 @@ public class CamelLanguageServerPreferenceManager {
 	static final String CAMEL_CATALOG_VERSION_PREF_KEY = "Camel catalog version";
 	static final String CAMEL_ADDITIONAL_COMPONENT_PREF_KEY = "extra-components";
 	static final String CAMEL_CATALOG_RUNTIME_PROVIDER_PREF_KEY = "Camel catalog runtime provider";
+	public static final String KAFKA_CONNECTION_URL = "Kafka Connection URL";
 
 	public Map<String, Map<String, Object>> getPreferenceAsLanguageServerFormat() {
 		IEclipsePreferences preferences = getCamelPreferenceNode();
@@ -44,6 +45,7 @@ public class CamelLanguageServerPreferenceManager {
 		camelSettings.put(CAMEL_CATALOG_VERSION_PREF_KEY, preferences.get(CAMEL_CATALOG_VERSION_PREF_KEY, null));
 		camelSettings.put(CAMEL_CATALOG_RUNTIME_PROVIDER_PREF_KEY, preferences.get(CAMEL_CATALOG_RUNTIME_PROVIDER_PREF_KEY, null));
 		camelSettings.put(CAMEL_ADDITIONAL_COMPONENT_PREF_KEY, getAdditionalComponentIfValid(preferences));
+		camelSettings.put(KAFKA_CONNECTION_URL, preferences.get(KAFKA_CONNECTION_URL, "localhost:9092"));
 		settings.put(TOP_NODE_CAMEL_KEY, camelSettings );
 		return settings;
 	}

--- a/com.github.camel-tooling.lsp.eclipse.client/src/com/github/cameltooling/eclipse/preferences/CamelLanguageServerPreferencePage.java
+++ b/com.github.camel-tooling.lsp.eclipse.client/src/com/github/cameltooling/eclipse/preferences/CamelLanguageServerPreferencePage.java
@@ -47,5 +47,6 @@ public class CamelLanguageServerPreferencePage extends FieldEditorPreferencePage
 				CamelRuntimeProvider.getComboFieldEditorInputs(),
 				fieldEditorParent));
 		addField(new MultilineStringFieldEditor(CamelLanguageServerPreferenceManager.CAMEL_ADDITIONAL_COMPONENT_PREF_KEY, Messages.camelAdditionalComponentSettings, fieldEditorParent));
+		addField(new StringFieldEditor(CamelLanguageServerPreferenceManager.KAFKA_CONNECTION_URL, Messages.kafkaConnectionUrlSettings, fieldEditorParent));
 	}
 }


### PR DESCRIPTION
![kafkaConnectionUrl-Eclipse](https://user-images.githubusercontent.com/1105127/114894347-d9753500-9e0e-11eb-90cc-d219a513cf16.gif)

requires https://github.com/camel-tooling/camel-language-server/pull/585

no test because kafka server is nto working in an OSGi environment :'-(