### PR TITLE
FUSETOOLS2-1049 - Upgrade LSP4J in Target Platform to 0.12.0

### DIFF
--- a/camel-lsp-target-platform/camel-lsp-target-platform.target
+++ b/camel-lsp-target-platform/camel-lsp-target-platform.target
@@ -16,9 +16,12 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.lsp4e" version="0.13.5.202103011336"/>
-<unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.10.0.v20201105-1605"/>
 <unit id="org.eclipse.wst.xml_ui.feature.feature.group" version="3.21.0.v202102222242"/>
 <repository location="https://download.eclipse.org/releases/2021-03"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.12.0.v20210402-1310"/>
+<repository location="https://download.eclipse.org/lsp4j/updates/releases/0.12.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.reddeer.codegen.feature.feature.group" version="3.3.0.v20210310-2044"/>


### PR DESCRIPTION
it allows Language Server Protocol 3.16 compatibility.
it is required as Camel Language Server is using label for
DocumentSymbolprovider

