### PR TITLE
FUSETOOLS2-1129 - upgrade to Camel LS 1.3.0

### DIFF
--- a/com.github.camel-tooling.lsp.eclipse.client/pom.xml
+++ b/com.github.camel-tooling.lsp.eclipse.client/pom.xml
@@ -14,7 +14,7 @@
 	<packaging>eclipse-plugin</packaging>
 	
 	<properties>
-		<camel-lsp-server-version>1.2.0-SNAPSHOT</camel-lsp-server-version>
+		<camel-lsp-server-version>1.3.0-SNAPSHOT</camel-lsp-server-version>
 		<tycho-version>0.26.0</tycho-version>
 	</properties>
 	


### PR DESCRIPTION
this Camel LS now requires Java 11 but Eclipse was already requiring it
so there is no impact

