### PR TITLE
FUSETOOLS2-1298 - migrate default branch name from master to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           command: mvn clean verify
       - when:
           condition:
-            equal: [master, << pipeline.git.branch >>]
+            equal: [main, << pipeline.git.branch >>]
           steps:
             - run:
                 name: Sonar Analysis

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -12,7 +12,7 @@ SHA=`git rev-parse --verify HEAD`
 cd $HOME
 git config --global user.email "circleci@circle-ci.org"
 git config --global user.name "circle-ci"
-git clone --quiet --branch=master https://${GH_PAGES_DEPLOY}@github.com/camel-tooling/camel-lsp-client-eclipse-update-site.git gh-pages > /dev/null
+git clone --quiet --branch=main https://${GH_PAGES_DEPLOY}@github.com/camel-tooling/camel-lsp-client-eclipse-update-site.git gh-pages > /dev/null
 cd gh-pages
 
 # delete existing data
@@ -23,6 +23,6 @@ cp -r $REPO_PATH/com.github.camel-tooling.lsp.eclipse.updatesite/target/updatesi
 git add -f .
 git status
 git commit -m "Deploy ${DEPLOY_REPO_ROOT} update site to GitHub Pages: ${CIRCLE_SHA1} from Circle CI build $CIRCLE_BUILD_NUM"
-git push -fq origin master > /dev/null
+git push -fq origin main > /dev/null
 # return to original path
 cd $REPO_PATH

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 ## Rebase & Merge default requirements
 
-1. Green build for master branch
+1. Green build for main branch
 2. Wait 24 hours after PR creation
 3. Green job for PR
 4. Approved PR
@@ -22,4 +22,4 @@
 1. [ ] Tagged with relevant **PR labels**
 2. [ ] Green **job for PR**
 3. [ ] PR was created more than **24 hours ago** or **All committers approved** it
-4. [ ] Green **master** branch build
+4. [ ] Green **main** branch build

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,9 +5,9 @@ name: Test on Windows
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/website/index.html
+++ b/website/index.html
@@ -11,7 +11,7 @@
                 <p><b>This is the Update Site for Camel Tooling Language Server for Eclipse</b>
                 <blockquote style="border: 1px dashed #1778be; padding: 2px">
                         </br>
-                        To <a href="https://github.com/camel-tooling/camel-lsp-client-eclipse/blob/master/README.md">install</a> from this site, start up Eclipse, then do:<br/>
+                        To <a href="https://github.com/camel-tooling/camel-lsp-client-eclipse/blob/main/README.md">install</a> from this site, start up Eclipse, then do:<br/>
                         <code><strong>Help > Install New Software... ></strong></code></br>
                         Copy this site's URL into Eclipse, and hit Enter.</br>
                         When the site loads, select the features to install, or click the <code><strong>Select All</strong></code> button.</br>


### PR DESCRIPTION
requires migration of this repository and https://github.com/camel-tooling/camel-lsp-client-eclipse-update-site from `master` to `main` branch in GitHub web UI before merging