### PR TITLE
Upgrade Target Platform to 2023-03

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cimg/openjdk:11.0-browsers
+      - image: cimg/openjdk:17.0-browsers
     steps:
       - checkout
       - run:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: 17
         distribution: temurin
     - name: Cache Maven packages
       uses: actions/cache@v2

--- a/camel-lsp-target-platform/camel-lsp-target-platform.target
+++ b/camel-lsp-target-platform/camel-lsp-target-platform.target
@@ -1,44 +1,44 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target name="camel-lsp-eclipse" sequenceNumber="7">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.pde.feature.group" version="3.14.1100.v20220308-0310"/>
-<unit id="org.eclipse.pde.source.feature.group" version="3.14.1100.v20220308-0310"/>
-<unit id="org.eclipse.sdk.feature.group" version="4.23.0.v20220308-0722"/>
-<unit id="org.eclipse.sdk.tests.feature.group" version="4.23.0.v20220308-0722"/>
-<unit id="org.eclipse.test.feature.group" version="3.8.0.v20211210-1030"/>
-<unit id="org.eclipse.jface.text.tests" version="3.12.400.v20220210-1738"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.23/"/>
+<unit id="org.eclipse.pde.feature.group" version="3.14.1500.v20230302-0300"/>
+<unit id="org.eclipse.pde.source.feature.group" version="3.14.1500.v20230302-0300"/>
+<unit id="org.eclipse.sdk.feature.group" version="4.27.0.v20230302-0300"/>
+<unit id="org.eclipse.sdk.tests.feature.group" version="4.27.0.v20230302-0300"/>
+<unit id="org.eclipse.test.feature.group" version="3.8.400.v20230219-1319"/>
+<unit id="org.eclipse.jface.text.tests" version="3.13.0.v20230203-1344"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.27/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.assertj" version="3.20.2.v20210706-1104"/>
 <unit id="org.assertj.source" version="3.20.2.v20210706-1104"/>
-<repository location="https://download.eclipse.org/tools/orbit/R-builds/R20210825222808/repository"/>
+<repository location="https://download.eclipse.org/tools/orbit/R-builds/R20220302172233/repository"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.lsp4e" version="0.13.9.202202021529"/>
-<unit id="org.eclipse.lsp4e.jdt" version="0.10.1.202009250956"/>
-<unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.12.0.v20210402-1310"/>
-<unit id="org.eclipse.wst.xml_ui.feature.feature.group" version="3.25.0.v202201160258"/>
-<unit id="org.eclipse.ui.genericeditor" version="1.2.200.v20211217-1247"/>
-<repository location="https://download.eclipse.org/releases/2022-03"/>
+<unit id="org.eclipse.lsp4e" version="0.15.0.202211292024"/>
+<unit id="org.eclipse.lsp4e.jdt" version="0.10.2.202205031750"/>
+<unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.20.1.v20230228-1533"/>
+<unit id="org.eclipse.wst.xml_ui.feature.feature.group" version="3.29.0.v202212250111"/>
+<unit id="org.eclipse.ui.genericeditor" version="1.2.400.v20221207-1659"/>
+<repository location="https://download.eclipse.org/releases/2023-03"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.reddeer.codegen.feature.feature.group" version="4.1.0.v20220309-1055"/>
-<unit id="org.eclipse.reddeer.eclipse.feature.feature.group" version="4.1.0.v20220309-1055"/>
-<unit id="org.eclipse.reddeer.eclipse.feature.source.feature.group" version="4.1.0.v20220309-1055"/>
-<unit id="org.eclipse.reddeer.gef.spy.feature.feature.group" version="4.1.0.v20220309-1055"/>
-<unit id="org.eclipse.reddeer.graphiti.feature.feature.group" version="4.1.0.v20220309-1055"/>
-<unit id="org.eclipse.reddeer.graphiti.feature.source.feature.group" version="4.1.0.v20220309-1055"/>
-<unit id="org.eclipse.reddeer.logparser.feature.feature.group" version="4.1.0.v20220309-1055"/>
-<unit id="org.eclipse.reddeer.logparser.feature.source.feature.group" version="4.1.0.v20220309-1055"/>
-<unit id="org.eclipse.reddeer.recorder.feature.feature.group" version="4.1.0.v20220309-1055"/>
-<unit id="org.eclipse.reddeer.recorder.feature.source.feature.group" version="4.1.0.v20220309-1055"/>
-<unit id="org.eclipse.reddeer.spy.feature.feature.group" version="4.1.0.v20220309-1055"/>
-<unit id="org.eclipse.reddeer.swt.feature.feature.group" version="4.1.0.v20220309-1055"/>
-<unit id="org.eclipse.reddeer.swt.feature.source.feature.group" version="4.1.0.v20220309-1055"/>
-<unit id="org.eclipse.reddeer.ui.feature.feature.group" version="4.1.0.v20220309-1055"/>
-<unit id="org.eclipse.reddeer.ui.feature.source.feature.group" version="4.1.0.v20220309-1055"/>
-<repository location="https://download.eclipse.org/reddeer/releases/4.1.0"/>
+<unit id="org.eclipse.reddeer.codegen.feature.feature.group" version="4.5.0.v20230308-1253"/>
+<unit id="org.eclipse.reddeer.eclipse.feature.feature.group" version="4.5.0.v20230308-1253"/>
+<unit id="org.eclipse.reddeer.eclipse.feature.source.feature.group" version="4.5.0.v20230308-1253"/>
+<unit id="org.eclipse.reddeer.gef.spy.feature.feature.group" version="4.5.0.v20230308-1253"/>
+<unit id="org.eclipse.reddeer.graphiti.feature.feature.group" version="4.5.0.v20230308-1253"/>
+<unit id="org.eclipse.reddeer.graphiti.feature.source.feature.group" version="4.5.0.v20230308-1253"/>
+<unit id="org.eclipse.reddeer.logparser.feature.feature.group" version="4.5.0.v20230308-1253"/>
+<unit id="org.eclipse.reddeer.logparser.feature.source.feature.group" version="4.5.0.v20230308-1253"/>
+<unit id="org.eclipse.reddeer.recorder.feature.feature.group" version="4.5.0.v20230308-1253"/>
+<unit id="org.eclipse.reddeer.recorder.feature.source.feature.group" version="4.5.0.v20230308-1253"/>
+<unit id="org.eclipse.reddeer.spy.feature.feature.group" version="4.5.0.v20230308-1253"/>
+<unit id="org.eclipse.reddeer.swt.feature.feature.group" version="4.5.0.v20230308-1253"/>
+<unit id="org.eclipse.reddeer.swt.feature.source.feature.group" version="4.5.0.v20230308-1253"/>
+<unit id="org.eclipse.reddeer.ui.feature.feature.group" version="4.5.0.v20230308-1253"/>
+<unit id="org.eclipse.reddeer.ui.feature.source.feature.group" version="4.5.0.v20230308-1253"/>
+<repository location="https://download.eclipse.org/reddeer/releases/4.5.0"/>
 </location>
 </locations>
 </target>

--- a/com.github.camel-tooling.lsp.eclipse.client.tests.integration/.classpath
+++ b/com.github.camel-tooling.lsp.eclipse.client.tests.integration/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="src" path="src/main/java/"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/com.github.camel-tooling.lsp.eclipse.client.tests.integration/.project
+++ b/com.github.camel-tooling.lsp.eclipse.client.tests.integration/.project
@@ -25,8 +25,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>

--- a/com.github.camel-tooling.lsp.eclipse.client.tests.integration/.settings/org.eclipse.core.resources.prefs
+++ b/com.github.camel-tooling.lsp.eclipse.client.tests.integration/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/com.github.camel-tooling.lsp.eclipse.client.tests.integration/.settings/org.eclipse.jdt.core.prefs
+++ b/com.github.camel-tooling.lsp.eclipse.client.tests.integration/.settings/org.eclipse.jdt.core.prefs
@@ -1,11 +1,9 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
 org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.source=17

--- a/com.github.camel-tooling.lsp.eclipse.client.tests.integration/.settings/org.eclipse.m2e.core.prefs
+++ b/com.github.camel-tooling.lsp.eclipse.client.tests.integration/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/com.github.camel-tooling.lsp.eclipse.client.tests.integration/META-INF/MANIFEST.MF
+++ b/com.github.camel-tooling.lsp.eclipse.client.tests.integration/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.github.camel-tooling.eclipse.client.tests.integration;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.junit;bundle-version="4.12.0",
  org.assertj;bundle-version="1.7.1",

--- a/com.github.camel-tooling.lsp.eclipse.client.tests.ui/.project
+++ b/com.github.camel-tooling.lsp.eclipse.client.tests.ui/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.github.camel-tooling.lsp.eclipse.client.tests.ui</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/com.github.camel-tooling.lsp.eclipse.client.tests.ui/plugins/.project
+++ b/com.github.camel-tooling.lsp.eclipse.client.tests.ui/plugins/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>plugins</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/com.github.camel-tooling.lsp.eclipse.client.tests.ui/plugins/com.github.cameltooling.lsp.reddeer/.classpath
+++ b/com.github.camel-tooling.lsp.eclipse.client.tests.ui/plugins/com.github.cameltooling.lsp.reddeer/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/com.github.camel-tooling.lsp.eclipse.client.tests.ui/plugins/com.github.cameltooling.lsp.reddeer/META-INF/MANIFEST.MF
+++ b/com.github.camel-tooling.lsp.eclipse.client.tests.ui/plugins/com.github.cameltooling.lsp.reddeer/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.github.cameltooling.lsp.reddeer;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: com.github.cameltooling.lsp.reddeer.Activator
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.ide,
  org.eclipse.gef,

--- a/com.github.camel-tooling.lsp.eclipse.client.tests.ui/tests/.project
+++ b/com.github.camel-tooling.lsp.eclipse.client.tests.ui/tests/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>tests</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/com.github.camel-tooling.lsp.eclipse.client.tests.ui/tests/com.github.cameltooling.lsp.ui.tests/.classpath
+++ b/com.github.camel-tooling.lsp.eclipse.client.tests.ui/tests/com.github.cameltooling.lsp.ui.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/com.github.camel-tooling.lsp.eclipse.client.tests.ui/tests/com.github.cameltooling.lsp.ui.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/com.github.camel-tooling.lsp.eclipse.client.tests.ui/tests/com.github.cameltooling.lsp.ui.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,11 +1,11 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=17

--- a/com.github.camel-tooling.lsp.eclipse.client.tests.ui/tests/com.github.cameltooling.lsp.ui.tests/META-INF/MANIFEST.MF
+++ b/com.github.camel-tooling.lsp.eclipse.client.tests.ui/tests/com.github.cameltooling.lsp.ui.tests/META-INF/MANIFEST.MF
@@ -25,7 +25,7 @@ Require-Bundle: org.eclipse.ui,
  com.github.camel-tooling.eclipse.client;bundle-version="1.0.0",
  org.eclipse.reddeer.junit
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: %Bundle-Vendor
 Eclipse-RegisterBuddy: org.apache.log4j
 Eclipse-BundleShape: dir

--- a/com.github.camel-tooling.lsp.eclipse.client.tests.ui/tests/com.github.cameltooling.lsp.ui.tests/src/com/github/cameltooling/lsp/ui/tests/AdditionalComponentFeatureTest.java
+++ b/com.github.camel-tooling.lsp.eclipse.client.tests.ui/tests/com.github.cameltooling.lsp.ui.tests/src/com/github/cameltooling/lsp/ui/tests/AdditionalComponentFeatureTest.java
@@ -55,7 +55,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 @RunWith(RedDeerSuite.class)
 public class AdditionalComponentFeatureTest extends DefaultTest {
 
-	public static final String PROJECT_NAME = "additional-component-test";
+	public static final String PROJECT_NAME = "AdditionalComponentTest";
 	public static final String CAMEL_CONTEXT = "camel-context.xml";
 	public static final String SOURCE_TAB = "Source";
 	public static final String COMPONENT_PLACE = "uri";

--- a/com.github.camel-tooling.lsp.eclipse.client.tests.ui/tests/com.github.cameltooling.lsp.ui.tests/src/com/github/cameltooling/lsp/ui/tests/CamelCatalogVersionFeatureTest.java
+++ b/com.github.camel-tooling.lsp.eclipse.client.tests.ui/tests/com.github.cameltooling.lsp.ui.tests/src/com/github/cameltooling/lsp/ui/tests/CamelCatalogVersionFeatureTest.java
@@ -55,7 +55,7 @@ import com.github.cameltooling.lsp.reddeer.preference.CamelCatalogVersion;
 @RunWith(RedDeerSuite.class)
 public class CamelCatalogVersionFeatureTest extends DefaultTest {
 
-	public static final String PROJECT_NAME = "catalog-feature-test";
+	public static final String PROJECT_NAME = "CatalogFeatureTest";
 	public static final String CAMEL_CONTEXT = "camel-context.xml";
 	public static final String RESOURCES_CONTEXT_PATH = "resources/catalog-version-feature-context.xml";
 	public static final String COMPONENT = "file-watch";

--- a/com.github.camel-tooling.lsp.eclipse.client.tests.ui/tests/com.github.cameltooling.lsp.ui.tests/src/com/github/cameltooling/lsp/ui/tests/CamelRuntimeProviderFeatureTest.java
+++ b/com.github.camel-tooling.lsp.eclipse.client.tests.ui/tests/com.github.cameltooling.lsp.ui.tests/src/com/github/cameltooling/lsp/ui/tests/CamelRuntimeProviderFeatureTest.java
@@ -59,7 +59,7 @@ import com.github.cameltooling.lsp.ui.tests.utils.TimeoutPeriodManipulator;
 @UseParametersRunnerFactory(ParameterizedRequirementsRunnerFactory.class)
 public class CamelRuntimeProviderFeatureTest extends DefaultTest {
 
-	public static final String PROJECT_NAME = "catalog-feature-test";
+	public static final String PROJECT_NAME = "CatalogFeatureTest";
 	public static final String CAMEL_CONTEXT = "camel-context.xml";
 	public static final String RESOURCES_CONTEXT_PATH = "resources/catalog-version-feature-context.xml";
 	public static final String SOURCE_TAB = "Source";
@@ -98,7 +98,7 @@ public class CamelRuntimeProviderFeatureTest extends DefaultTest {
 				// runtime provider, knative available, mongo available, jmx available
 				{ "Spring Boot", true, true, true }, 
 				{ "Quarkus", true, true, false }, //knative is available in latest quarkus catalog
-				{ "Karaf", false, false, true } 
+				{ "Karaf", false, true, true } 
 				});
 	}
 

--- a/com.github.camel-tooling.lsp.eclipse.client.tests.ui/tests/com.github.cameltooling.lsp.ui.tests/src/com/github/cameltooling/lsp/ui/tests/JavaEditorCompletionTest.java
+++ b/com.github.camel-tooling.lsp.eclipse.client.tests.ui/tests/com.github.cameltooling.lsp.ui.tests/src/com/github/cameltooling/lsp/ui/tests/JavaEditorCompletionTest.java
@@ -53,7 +53,7 @@ import com.github.cameltooling.lsp.ui.tests.utils.TimeoutPeriodManipulator;
 @RunWith(RedDeerSuite.class)
 public class JavaEditorCompletionTest extends DefaultTest {
 
-	public static final String PROJECT_NAME = "java-dsl-completion-test";
+	public static final String PROJECT_NAME = "JavaDslCompletionTest";
 	public static final String CAMEL_ROUTE_NAME = "CamelRoute";
 	public static final String CAMEL_ROUTE = "CamelRoute.java";
 

--- a/com.github.camel-tooling.lsp.eclipse.client/.classpath
+++ b/com.github.camel-tooling.lsp.eclipse.client/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="src" path="src/"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/com.github.camel-tooling.lsp.eclipse.client/.project
+++ b/com.github.camel-tooling.lsp.eclipse.client/.project
@@ -25,8 +25,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>

--- a/com.github.camel-tooling.lsp.eclipse.client/.settings/org.eclipse.core.resources.prefs
+++ b/com.github.camel-tooling.lsp.eclipse.client/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/com.github.camel-tooling.lsp.eclipse.client/.settings/org.eclipse.jdt.core.prefs
+++ b/com.github.camel-tooling.lsp.eclipse.client/.settings/org.eclipse.jdt.core.prefs
@@ -1,11 +1,9 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
 org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.source=17

--- a/com.github.camel-tooling.lsp.eclipse.client/.settings/org.eclipse.m2e.core.prefs
+++ b/com.github.camel-tooling.lsp.eclipse.client/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/com.github.camel-tooling.lsp.eclipse.client/META-INF/MANIFEST.MF
+++ b/com.github.camel-tooling.lsp.eclipse.client/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.github.camel-tooling.eclipse.client;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.lsp4e;bundle-version="0.6.0",
  org.eclipse.core.runtime;bundle-version="3.13.0",

--- a/pom.xml
+++ b/pom.xml
@@ -12,12 +12,11 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho.version>2.7.5</tycho.version>
+		<tycho.version>3.0.4</tycho.version>
 		<base.name>Eclipse Client for Apache Camel Language Server</base.name>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<!-- compiler settings -->
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
+		<maven.compiler.release>17</maven.compiler.release>
 		<!-- sonar properties -->
 		<sonar.code.codeCoveragePlugin>jacoco</sonar.code.codeCoveragePlugin>
 		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
@@ -77,7 +76,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.10</version>
 				<configuration>
 					<append>true</append>
 					<includes>com.github.cameltooling.lsp.*,com.github.cameltooling.*</includes>
@@ -105,7 +104,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.2</version>
+				<version>3.1.0</version>
 				<configuration>
 					<argLine>${argLine}</argLine>
 				</configuration>
@@ -117,7 +116,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.10.1</version>
+					<version>3.11.0</version>
 					<configuration>
 						<source>${maven.compiler.source}</source>
 						<target>${maven.compiler.target}</target>


### PR DESCRIPTION
- moved to java 17 as requirement
- upgraded all dependencies as several requires to be upgraded due to
either java 17 or new TP
- adjust tests:
  - project name is used by default for module name and it
must a valid java identifier
  - MongoDB is now part of latest Karaf Camel catalog


