### PR TITLE
FUSETOOLS2-1905 - specify host for Sonar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
 		<!-- compiler settings -->
 		<maven.compiler.release>17</maven.compiler.release>
 		<!-- sonar properties -->
+		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<sonar.code.codeCoveragePlugin>jacoco</sonar.code.codeCoveragePlugin>
 		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
 		<sonar.test.inclusions>**/*Test.*,**/tests/**/*,**/*IT.*,**/**reddeer**/**/*</sonar.test.inclusions>


### PR DESCRIPTION
otherwise it is picking localhost by default

follow-up on https://github.com/camel-tooling/camel-lsp-client-eclipse/pull/207